### PR TITLE
Fixes menu when Spotify not running

### DIFF
--- a/SpotStatus/AppDelegate.swift
+++ b/SpotStatus/AppDelegate.swift
@@ -121,15 +121,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // assume Spotify isn't playing since we got an empty name
         if songName == "" {
-            button.title = displayName // Show the standby name if we have one. Will be "" otherwise.
             artist = ""
-            if displayName != "" {
-                // We have text to display, so don't display the icon.
+            if displayName == "" {
+                // By default, show the status bar icon.
+                button.title = ""
+                button.image = NSImage(named: "StatusBarButtonImage")
                 return
             }
-            // By default, show the status bar icon.
-            button.image = NSImage(named: "StatusBarButtonImage")
-            return
+            button.title = displayName // Show the standby name if we have one. Will be "" otherwise.
         }
         
         // At this point, we ARE playing music, and have a song/artist to display!

--- a/SpotStatus/Preferences.xib
+++ b/SpotStatus/Preferences.xib
@@ -23,7 +23,7 @@
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="18" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1fa-lm-MxI">
                         <rect key="frame" x="14" y="88" width="376" height="167"/>
@@ -76,14 +76,14 @@
                             </stackView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QD9-NQ-q26">
                                 <rect key="frame" x="-2" y="30" width="354" height="18"/>
-                                <buttonCell key="cell" type="check" title="Remove &quot;Remastered&quot; and other cruft from song name" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="id9-Fh-a5o">
+                                <buttonCell key="cell" type="check" title="Remove &quot;Remastered&quot; and other cruft from song name" bezelStyle="regularSquare" imagePosition="left" inset="2" id="id9-Fh-a5o">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aCc-mA-c3Q">
                                 <rect key="frame" x="-2" y="-2" width="252" height="18"/>
-                                <buttonCell key="cell" type="check" title="Show artist name in menu periodically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="f2N-Vp-O0t">
+                                <buttonCell key="cell" type="check" title="Show artist name in menu periodically" bezelStyle="regularSquare" imagePosition="left" inset="2" id="f2N-Vp-O0t">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>


### PR DESCRIPTION
If Spotify is not running, but SpotStatus is loaded, there was no way to get to the Quit & Preferences menu items. That meant there was no way to quit the app.

I also found that there would be times that the SpotStatus icon was not shown when Spotify wasn't running. This fixes that as well.

Finally, this updates the default preferences (setting "remove cruft" and "show artist" to no) to address issue #3. Since `defaults.bool(forKey:)` returns a boolean, not an optional, there didn't seem a clean way to determine if the user wanted the options off, or hadn't set them yet. So, I set the starting conditions to be off.