### PR TITLE
Prevent Spotify from automatically relaunching after quitting

### DIFF
--- a/SpotStatus/AppDelegate.swift
+++ b/SpotStatus/AppDelegate.swift
@@ -31,16 +31,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     """
     
     let currentArtistScript = """
-    tell application "Spotify"
-        return artist of current track
-    end tell
+    if application "Spotify" is running then
+        tell application "Spotify"
+            return artist of current track
+        end tell
+    else
+        return ""
+    end if
     """
     
     let songURLScript = """
-    tell application "Spotify"
-        return spotify url of current track
-    end tell
-        
+    if application "Spotify" is running then
+        tell application "Spotify"
+            return spotify url of current track
+        end tell
+    else
+        return ""
+    end if
+
     """
     
     


### PR DESCRIPTION
While SpotStatus is running, if you quit Spotify it gets reopened automatically. This is because the AppleScript is "telling" the Spotify app to return some info, which forces the app to open.

There are perhaps less repetitive ways of accomplishing this fix. But this PR works and the few other techniques I tried did not. 